### PR TITLE
Enhance docker-compose and installation script with health checks and updated login information for FileBrowser

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,12 +17,25 @@ services:
       - ./qbittorrent/config:/config
       - /root/Downloads:/downloads
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:${WEBUI_PORT} || exit 1"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   filebrowser:
     image: filebrowser/filebrowser
     container_name: infinity_box_filebrowser
+    user: "1000:1000"
     volumes:
       - /root/Downloads:/srv
+      - ./filebrowser/database.db:/database.db
     ports:
       - "${FILE_SERVER_PORT}:80"
     restart: unless-stopped
+    command: --root /srv --database /database.db
+    healthcheck:
+      test: ["CMD", "/filebrowser", "healthcheck"]
+      interval: 10s
+      timeout: 5s
+      retries: 3

--- a/infinitybox_install.sh
+++ b/infinitybox_install.sh
@@ -175,12 +175,6 @@ MACHINE_IP=$(curl ipinfo.io/ip)
 echo -e "${YELLOW}Access qBittorrent at: http://${MACHINE_IP}:${QB_PORT}${NC}"
 echo -e "${YELLOW}Access File Server at: http://${MACHINE_IP}:${FILE_SERVER_PORT}${NC}"
 
-# Display FileBrowser login information
-echo -e "${YELLOW}FileBrowser Login Information:${NC}"
-echo -e "URL: http://${MACHINE_IP}:${FILE_SERVER_PORT}"
-echo -e "Username: admin"
-echo -e "Password: admin${NC}"
-
 # Retrieve and display qBittorrent Docker container logs
 QB_LOGS=$(docker-compose --project-name infinitybox logs qbittorrent 2>&1)
 
@@ -188,8 +182,20 @@ sleep 10
 # Extract and display the temporary password
 TEMP_PASSWORD=$(echo "$QB_LOGS" | grep -oP "The WebUI administrator password was not set. A temporary password is provided for this session: \K\S+")
 
-# Display FileBrowser login information
+# Retrieve and display FileBrowser Docker container logs
+FB_LOGS=$(docker-compose --project-name infinitybox logs filebrowser 2>&1)
+
+# Extract and display the temporary password for FileBrowser
+FB_TEMP_PASSWORD=$(echo "$FB_LOGS" | grep -oP "User 'admin' initialized with randomly generated password: \K\S+")
+
+# Display qBittorrent login information
 echo -e "${YELLOW}qBittorrent Login Information:${NC}"
 echo -e "URL: http://${MACHINE_IP}:${QB_PORT}"
 echo -e "Username: admin"
 echo -e "Temporary Password: ${TEMP_PASSWORD}${NC}"
+
+# Display FileBrowser login information
+echo -e "${YELLOW}FileBrowser Login Information:${NC}"
+echo -e "URL: http://${MACHINE_IP}:${FILE_SERVER_PORT}"
+echo -e "Username: admin"
+echo -e "Temporary Password: ${FB_TEMP_PASSWORD}${NC}"


### PR DESCRIPTION
Add health checks to the docker-compose configuration for improved reliability and update the installation script to display the temporary password for FileBrowser. This ensures users have the correct login information upon setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health checks for qBittorrent and FileBrowser services to improve runtime visibility.
  * Introduced explicit user and database configuration for FileBrowser, including a dedicated database volume and root/database path setup.
  * Installation script now displays FileBrowser login details (URL, username, temporary password) alongside qBittorrent credentials.

* **Chores**
  * Consolidated and reordered final installation messages to present comprehensive service access information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->