### PR TITLE
Add Jellyfin support and update installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,37 @@ Welcome to Infinite Box, a super cool and easy-to-use Dockerized environment des
 
 ### Installation
 
-1. To quickly install Infinite Box, run the following commands:
+There are two ways to install Infinite Box:
 
-    ```bash
-    sudo rm -f infinitybox_install.sh && sudo rm -rf Infinite-box && sudo apt-get update && sudo apt-get install wget -y && sudo wget https://raw.githubusercontent.com/Niraj-Dilshan/Infinite-box/main/infinitybox_install.sh && chmod +x infinitybox_install.sh && ./infinitybox_install.sh
-    ```
-2. Follow the prompts to configure ports for qBittorrent and FileBrowser.
+**1. Standard Installation (qBittorrent + FileBrowser)**
 
-3. Once the installation is complete, access your services:
-    - qBittorrent: [http://localhost:8181](http://localhost:8181) (Default ports)
-    - FileBrowser: [http://localhost:8180](http://localhost:8180) (Default ports)
+To quickly install the standard version of Infinite Box, run the following command:
 
-    **FileBrowser Login Information:**
-    - Username: admin
-    - Password: admin
+```bash
+sudo rm -f infinitybox_install.sh && sudo rm -rf Infinite-box && sudo apt-get update && sudo apt-get install wget -y && sudo wget https://raw.githubusercontent.com/Niraj-Dilshan/Infinite-box/main/infinitybox_install.sh && chmod +x infinitybox_install.sh && ./infinitybox_install.sh
+```
+
+**2. Installation with Jellyfin Media Server**
+
+If you want to include the Jellyfin media server for streaming your downloaded content, use this command instead:
+
+```bash
+sudo rm -f infinitybox_jellyfin_install.sh && sudo rm -rf Infinite-box && sudo apt-get update && sudo apt-get install wget -y && sudo wget https://raw.githubusercontent.com/Niraj-Dilshan/Infinite-box/main/infinitybox_jellyfin_install.sh && chmod +x infinitybox_jellyfin_install.sh && ./infinitybox_jellyfin_install.sh
+```
+
+After running either of the installation commands, follow the prompts to configure the necessary ports.
+
+### Accessing Your Services
+
+Once the installation is complete, you can access your services at the following default ports (or the custom ports you configured):
+
+- **qBittorrent**: `http://localhost:8181`
+- **FileBrowser**: `http://localhost:8180`
+- **Jellyfin** (if installed): `http://localhost:8096`
+
+**FileBrowser Login Information:**
+- Username: admin
+- Password: admin
 
 ## Infinite Box Project Overview
 
@@ -43,6 +60,11 @@ Welcome to Infinite Box, a super cool and easy-to-use Dockerized environment des
 
 - **Role in Project:** FileBrowser complements qBittorrent by providing a web-based file management system. Users can organize, access, and share their downloaded files using FileBrowser.
 
+#### 3. Jellyfin (Optional)
+
+- **Description:** Jellyfin is a free and open-source media server that allows you to organize, manage, and stream your media files.
+- **Role in Project:** When installed, Jellyfin provides a complete media center solution, allowing you to stream the content downloaded via qBittorrent to various devices.
+
 ## Project Architecture Overview
 
 ### Infinite Box Setup
@@ -54,18 +76,24 @@ The Infinite Box project combines qBittorrent and FileBrowser within a Dockerize
 #### qBittorrent Container
 
 - Hosts the qBittorrent application.
-- Exposes a web-based user interface accessible at [http://localhost:8181](http://localhost:8181).
+- Exposes a web-based user interface accessible at `http://localhost:8181`.
 - Downloads and manages torrents on the host system.
 
 #### FileBrowser Container
 
 - Hosts the FileBrowser application.
-- Provides a web-based file management interface at [http://localhost:8180](http://localhost:8180).
+- Provides a web-based file management interface at `http://localhost:8180`.
 - Allows users to navigate, upload, and download files.
+
+#### Jellyfin Container (Optional)
+
+- Hosts the Jellyfin media server application.
+- Provides a web-based media streaming interface at `http://localhost:8096`.
+- Allows users to stream media from the shared download directory.
 
 #### Interaction
 
-- Users interact with the qBittorrent and FileBrowser interfaces through web browsers. qBittorrent manages BitTorrent activities, while FileBrowser handles file management.
+- Users interact with the qBittorrent, FileBrowser, and Jellyfin interfaces through web browsers. qBittorrent manages BitTorrent activities, FileBrowser handles file management, and Jellyfin provides media streaming.
 
 #### Configuration
 
@@ -73,7 +101,7 @@ The Infinite Box project combines qBittorrent and FileBrowser within a Dockerize
 
 #### Ease of Use
 
-- The installation script (`infinitybox_install.sh`) streamlines the setup process, prompting users for necessary configurations.
+- The installation scripts (`infinitybox_install.sh` and `infinitybox_jellyfin_install.sh`) streamline the setup process, prompting users for necessary configurations.
 
 #### Portability
 
@@ -87,6 +115,7 @@ This project uses the following Docker images:
 
 - [LinuxServer/qBittorrent](https://hub.docker.com/r/linuxserver/qbittorrent): Docker image for qBittorrent.
 - [FileBrowser/FileBrowser](https://hub.docker.com/r/filebrowser/filebrowser): Docker image for FileBrowser.
+- [Jellyfin/Jellyfin](https://hub.docker.com/r/jellyfin/jellyfin): Docker image for Jellyfin.
 
 ## License
 

--- a/docker-compose-jellyfin.yml
+++ b/docker-compose-jellyfin.yml
@@ -1,0 +1,58 @@
+services:
+  qbittorrent:
+    image: lscr.io/linuxserver/qbittorrent:latest
+    container_name: infinity_box_qbittorrent
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Etc/UTC
+      - WEBUI_PORT=${WEBUI_PORT}
+    ports:
+      - "${WEBUI_PORT}:${WEBUI_PORT}"
+      - "6881:6881"
+      - "6881:6881/udp"
+    volumes:
+      - ./qbittorrent/config:/config
+      - /root/Downloads:/downloads
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:${WEBUI_PORT} || exit 1"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
+
+  filebrowser:
+    image: filebrowser/filebrowser
+    container_name: infinity_box_filebrowser
+    user: "1000:1000"
+    volumes:
+      - /root/Downloads:/srv
+      - ./filebrowser/database.db:/database.db
+    ports:
+      - "${FILE_SERVER_PORT}:80"
+    restart: unless-stopped
+    command: --root /srv --database /database.db
+    healthcheck:
+      test: ["CMD", "/filebrowser", "healthcheck"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  jellyfin:
+    image: jellyfin/jellyfin
+    container_name: infinity_box_jellyfin
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Etc/UTC
+    ports:
+      - "${JELLYFIN_PORT}:8096"
+    volumes:
+      - ./jellyfin/config:/config
+      - /root/Downloads:/media
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8096/health || exit 1"]
+      interval: 1m
+      timeout: 10s
+      retries: 3

--- a/infinitybox_jellyfin_install.sh
+++ b/infinitybox_jellyfin_install.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+
+# Colors for text formatting
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to display custom ASCII art message
+display_custom_message() {
+    echo -e "${YELLOW}
+ooooo oooo   oooo ooooooooooo ooooo oooo   oooo ooooo ooooooooooo ooooo  oooo      oooooooooo    ooooooo   ooooo  oooo 
+ 888   8888o  88   888    88   888   8888o  88   888  88  888  88   888  88         888    888 o888   888o   888  88   
+ 888   88 888o88   888ooo8     888   88 888o88   888      888         888           888oooo88  888     888     888     
+ 888   88   8888   888         888   88   8888   888      888         888           888    888 888o   o888    88 888   
+o888o o88o    88  o888o       o888o o88o    88  o888o    o888o       o888o         o888ooo888    88ooo88   o88o  o888o 
+${NC}"
+}
+
+# Function to check the Linux distribution
+check_distribution() {
+    if [ -f "/etc/os-release" ]; then
+        source /etc/os-release
+        DISTRIBUTION=$ID
+    elif [ -f "/etc/lsb-release" ]; then
+        source /etc/lsb-release
+        DISTRIBUTION=$DISTRIB_ID
+    else
+        echo -e "${RED}Unable to determine the Linux distribution. Exiting.${NC}"
+        exit 1
+    fi
+}
+
+# Function to perform system updates based on the distribution
+perform_system_updates() {
+    echo -e "${YELLOW}Updating system...${NC}"
+    case $DISTRIBUTION in
+        "ubuntu" | "debian")
+            apt update && apt upgrade -y
+            ;;
+        "fedora")
+            dnf update -y
+            ;;
+        *)
+            echo -e "${RED}Unsupported distribution: $DISTRIBUTION. Exiting.${NC}"
+            exit 1
+            ;;
+    esac
+}
+
+# Function to install Docker based on the distribution
+install_docker() {
+    echo -e "${YELLOW}Installing Docker...${NC}"
+    case $DISTRIBUTION in
+        "ubuntu" | "debian")
+            apt install docker.io -y
+            ;;
+        "fedora")
+            dnf install docker -y
+            ;;
+        *)
+            echo -e "${RED}Unsupported distribution: $DISTRIBUTION. Exiting.${NC}"
+            exit 1
+            ;;
+    esac
+}
+
+# Function to install Docker Compose based on the distribution
+install_docker_compose() {
+    echo -e "${YELLOW}Installing Docker Compose...${NC}"
+    case $DISTRIBUTION in
+        "ubuntu" | "debian")
+            apt install docker-compose -y
+            ;;
+        "fedora")
+            dnf install docker-compose -y
+            ;;
+        *)
+            echo -e "${RED}Unsupported distribution: $DISTRIBUTION. Exiting.${NC}"
+            exit 1
+            ;;
+    esac
+}
+
+# Function to get user input for port numbers and update the .env file
+get_user_input() {
+    read -p "Enter the qBittorrent web UI port (default: 8181): " QB_PORT
+    QB_PORT=${QB_PORT:-8181}
+
+    read -p "Enter the File Server port (default: 8180): " FILE_SERVER_PORT
+    FILE_SERVER_PORT=${FILE_SERVER_PORT:-8180}
+
+    read -p "Enter the Jellyfin port (default: 8096): " JELLYFIN_PORT
+    JELLYFIN_PORT=${JELLYFIN_PORT:-8096}
+
+    # Update .env file
+    echo "WEBUI_PORT=$QB_PORT" > .env
+    echo "FILE_SERVER_PORT=$FILE_SERVER_PORT" >> .env
+    echo "JELLYFIN_PORT=$JELLYFIN_PORT" >> .env
+}
+
+# Display the custom ASCII art message
+display_custom_message
+
+# Check if Git is installed
+if ! command -v git &> /dev/null; then
+    echo -e "${YELLOW}Git is not installed. Installing Git...${NC}"
+    check_distribution
+    case $DISTRIBUTION in
+        "ubuntu" | "debian")
+            apt install git -y
+            ;;
+        "fedora")
+            dnf install git -y
+            ;;
+        *)
+            echo -e "${RED}Unsupported distribution: $DISTRIBUTION. Exiting.${NC}"
+            exit 1
+            ;;
+    esac
+fi
+
+# Clone the GitHub repository
+echo -e "${YELLOW}Cloning the Infinite-box repository...${NC}"
+git clone https://github.com/Niraj-Dilshan/Infinite-box.git
+
+# Change into the repository directory
+cd Infinite-box || exit
+
+# Check the Linux distribution
+check_distribution
+
+# Perform system updates
+perform_system_updates
+
+# Get user input for port numbers and update the .env file
+get_user_input
+
+# Check if Docker is installed
+if ! command -v docker &> /dev/null; then
+    install_docker
+fi
+
+# Check if Docker Compose is installed
+if ! command -v docker-compose &> /dev/null; then
+    install_docker_compose
+fi
+
+# Display a warning about overwriting existing containers
+read -p "Warning: This script will attempt to recreate containers. Do you want to continue? (y/n):" -r
+echo
+
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo -e "${RED}Installation aborted.${NC}"
+    exit 1
+fi
+
+# Pull Docker images
+docker-compose -f docker-compose-jellyfin.yml --project-name infinitybox-jellyfin pull
+
+# Create and start the Docker containers
+docker-compose -f docker-compose-jellyfin.yml --project-name infinitybox-jellyfin up -d
+
+# Check for errors during docker-compose
+if [ $? -ne 0 ]; then
+    echo -e "${RED}Error: Docker containers failed to start. Check the logs for more details.${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}Installation completed successfully INFINITY Box with Jellyfin is up and ready.${NC}"
+
+# Retrieve port numbers from the .env file
+QB_PORT=$(grep WEBUI_PORT .env | cut -d '=' -f2)
+FILE_SERVER_PORT=$(grep FILE_SERVER_PORT .env | cut -d '=' -f2)
+JELLYFIN_PORT=$(grep JELLYFIN_PORT .env | cut -d '=' -f2)
+
+# Get the machine's IP address
+MACHINE_IP=$(curl ipinfo.io/ip)
+
+echo -e "${YELLOW}Access qBittorrent at: http://${MACHINE_IP}:${QB_PORT}${NC}"
+echo -e "${YELLOW}Access File Server at: http://${MACHINE_IP}:${FILE_SERVER_PORT}${NC}"
+echo -e "${YELLOW}Access Jellyfin at: http://${MACHINE_IP}:${JELLYFIN_PORT}${NC}"
+
+# Retrieve and display qBittorrent Docker container logs
+QB_LOGS=$(docker-compose -f docker-compose-jellyfin.yml --project-name infinitybox-jellyfin logs qbittorrent 2>&1)
+
+sleep 10
+# Extract and display the temporary password
+TEMP_PASSWORD=$(echo "$QB_LOGS" | grep -oP "The WebUI administrator password was not set. A temporary password is provided for this session: \K\S+")
+
+# Retrieve and display FileBrowser Docker container logs
+FB_LOGS=$(docker-compose -f docker-compose-jellyfin.yml --project-name infinitybox-jellyfin logs filebrowser 2>&1)
+
+# Extract and display the temporary password for FileBrowser
+FB_TEMP_PASSWORD=$(echo "$FB_LOGS" | grep -oP "User 'admin' initialized with randomly generated password: \K\S+")
+
+# Display qBittorrent login information
+echo -e "${YELLOW}qBittorrent Login Information:${NC}"
+echo -e "URL: http://${MACHINE_IP}:${QB_PORT}"
+echo -e "Username: admin"
+echo -e "Temporary Password: ${TEMP_PASSWORD}${NC}"
+
+# Display FileBrowser login information
+echo -e "${YELLOW}FileBrowser Login Information:${NC}"
+echo -e "URL: http://${MACHINE_IP}:${FILE_SERVER_PORT}"
+echo -e "Username: admin"
+echo -e "Temporary Password: ${FB_TEMP_PASSWORD}${NC}"


### PR DESCRIPTION
Introduce Jellyfin as an optional media server in the Infinite Box setup and update the installation instructions to include a dedicated script for Jellyfin. Provide details on accessing Jellyfin and its role in the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Jellyfin media server support with a dedicated Docker Compose configuration.
  * Introduced an automated Jellyfin-enabled install script with port selection and .env setup.

* **Documentation**
  * Expanded installation guide with separate standard and Jellyfin paths, commands, and default ports.
  * Updated overview, architecture, and container sections to include Jellyfin.
  * Clarified service access URLs and login details with consistent formatting.

* **Chores**
  * Implemented health checks and environment-driven port mappings in the Jellyfin compose configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->